### PR TITLE
Fix sed: unmatched '@' error.

### DIFF
--- a/start-kafka.sh
+++ b/start-kafka.sh
@@ -26,7 +26,7 @@ if [[ -z "$KAFKA_ADVERTISED_PORT" && \
   -z "$KAFKA_LISTENERS" && \
   -z "$KAFKA_ADVERTISED_LISTENERS" && \
   -S /var/run/docker.sock ]]; then
-    KAFKA_ADVERTISED_PORT=$(docker port "$(hostname)" $KAFKA_PORT | sed -r 's/.*:(.*)/\1/g')
+    KAFKA_ADVERTISED_PORT=$(docker port "$(hostname)" $KAFKA_PORT | sed -r 's/.*:(.*)/\1/g') | head -n1
     export KAFKA_ADVERTISED_PORT
 fi
 


### PR DESCRIPTION
When restarting a container `docker port` reports more than one port. Pick the first port and complete startup. The unmatched '@' is from a newline at the end of the string.